### PR TITLE
Add: タスク詳細画面に時間計測機能を設定

### DIFF
--- a/app/controllers/api/v1/works_controller.rb
+++ b/app/controllers/api/v1/works_controller.rb
@@ -1,2 +1,27 @@
 class Api::V1::WorksController < ApplicationController
+  def create
+    @work = Work.new(work_params)
+    @task = Task.find_by(task_params)
+    @work.work_time = @work.end_at - @work.start_at
+    @work.hourly_wage = 1000
+    # @work.hourly_wage = current_user.current_hourly_wage
+    # binding.pry
+    @task.total_time += @work.work_time
+    @task.total_wage += (@work.hourly_wage * @work.work_time / 60 / 60).floor
+    if @work.save && @task.save
+      render json: { work: @work, task: @task }
+    else
+      render json: @work.errors, status: :bad_request
+    end
+  end
+
+  private
+
+  def work_params
+    params.require(:work).permit(:start_at, :end_at, :task_id)
+  end
+
+  def task_params
+    params.require(:task).permit(:id)
+  end
 end

--- a/app/javascript/pages/task/components/StopWatchFunction.vue
+++ b/app/javascript/pages/task/components/StopWatchFunction.vue
@@ -1,0 +1,114 @@
+<template>
+  <!-- <div class="flex "></div> -->
+  <div class="text-center bg-gray-100 shadow h-96 w-96 mx-auto rounded-full">
+    <div class="pt-32">
+      <p class="text-6xl mb-10">
+        {{ h }} : {{ m }} : {{ s }}
+      </p>
+      <button
+        v-show="watch"
+        class="inline-flex items-center bg-blue-400 border-0 py-1 px-3 focus:outline-none hover:bg-gray-500 rounded text-base mt-4 my-40"
+        @click="start"
+      >
+        計測スタート
+      </button>
+      <button
+        v-show="!watch"
+        class="inline-flex items-center bg-blue-400 border-0 py-1 px-3 focus:outline-none hover:bg-gray-500 rounded text-base mt-4 my-40"
+        @click="end"
+      >
+        計測ストップ
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'StopWatchFunction',
+  props: {
+    task: {
+      type: Object,
+      required: true,
+      id: {
+        type: Number,
+        required: true
+      },
+      title: {
+        type: String,
+        required: true
+      },
+      total_wage: {
+        type: Number,
+        required: true
+      },
+      total_time: {
+        type: Number,
+        required: true
+      },
+      user_id: {
+        type: Number,
+        required: true
+      }
+    }
+  },
+  data() {
+    return {
+      startTime: 0 ,
+      pastTime: 0 ,
+      timerObj: null,
+      work :{
+        start_at :'',
+        end_at :'',
+        task_id :''
+      },
+      watch: true
+    }
+  },
+
+  computed: {
+    h(){
+      var h = Math.floor( this.pastTime / 3600000 % 60 )
+      return ( '0' + h ).slice(-2)
+      },
+    m(){
+      var m = Math.floor( this.pastTime / 60000 % 60 )
+      return ( '0' + m ).slice(-2)
+      },
+    s(){
+      var s = Math.floor( this.pastTime / 1000 % 60 )
+      return ( '0' + s ).slice(-2)
+      }
+  },
+
+  methods: {
+    countUp(){
+      return this.pastTime = Date.now() - this.startTime
+    },
+    start(){
+      this.startTime = Date.now()
+      this.$set(this.work, 'start_at', Date())
+      var self = this
+
+      this.timerObj = setInterval(function(){
+        self.countUp()
+      },10)
+      this.watch = false
+    },
+
+    end(){
+      clearInterval( this.timerObj )
+      this.$set(this.work, 'end_at', Date())
+      this.$set(this.work, 'task_id', this.task.id)
+      this.startTime = 0
+      this.pastTime = 0
+      this.timerObj = null
+      this.watch = true
+      this.$emit('create-work', this.work, this.task)
+    },
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/app/javascript/pages/task/components/TaskEditModal.vue
+++ b/app/javascript/pages/task/components/TaskEditModal.vue
@@ -116,18 +116,8 @@ export default {
       }
     }
   },
-  // data() {
-  //   return {
-  //     task: {
-  //       title: ''
-  //     }
-  //   }
-  // },
 
   methods: {
-    // handleCreateTask() {
-    //   this.$emit('create-task', this.task)
-    // },
     handleCloseModal() {
       this.$emit('close-task-edit-modal')
     },
@@ -139,7 +129,6 @@ export default {
       this.$set(this.task, 'total_wage', "0")
       this.$emit('reset-task', this.task)
     },
-
     handleDeleteTask() {
       this.$emit('delete-task', this.task)
     }

--- a/app/javascript/pages/task/components/TaskFinishModal.vue
+++ b/app/javascript/pages/task/components/TaskFinishModal.vue
@@ -1,0 +1,157 @@
+<template>
+  <div
+    class="fixed z-10 inset-0 overflow-y-auto"
+    aria-labelledby="modal-title"
+    role="dialog"
+    aria-modal="true"
+  >
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+      <div
+        class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+        aria-hidden="true"
+      />
+      <span
+        class="hidden sm:inline-block sm:align-middle sm:h-screen"
+        aria-hidden="true"
+      >&#8203;</span>
+      <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+        <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <div class="sm:flex sm:items-start">
+            <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+              <h3
+                id="modal-title"
+                class="text-lg leading-6 font-medium text-gray-900"
+              >
+                お疲れさまでした！！
+              </h3>
+              <div class="mt-2">
+                <p class="text-sm text-gray-800">
+                  今回は
+                  <span>{{ work_timeH }}</span>時間
+                  <span>{{ work_timeM }}</span>分
+                  <span>{{ work_timeS }}</span>秒で
+                  <br>
+                  <span>{{ task_take_money }}</span>円分の働きとなりました！！
+                </p>
+                <br>
+                <p class="text-sm text-gray-800">
+                  これまでの累計時間は
+                  <span>{{ total_timeH }}</span>時間
+                  <span>{{ total_timeM }}</span>分
+                  <span>{{ total_timeS }}</span>秒
+                  となり
+                  <br>
+                  累計の金額は<span>{{ task.total_wage }}</span>円となりました！
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <router-link
+            :to="{ name: 'TaskIndex' }"
+            type="button"
+            class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:ml-3 sm:w-auto sm:text-sm"
+          >
+            タスク一覧へ
+          </router-link>
+          <button
+            type="button"
+            class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
+            @click="handleCloseModal"
+          >
+            もう一度計測する
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+
+export default {
+  name: "TaskFinishModal",
+  props: {
+    work: {
+      type: Object,
+      required: true,
+      id: {
+        type: Number,
+        required: true
+      },
+      work_time: {
+        type: Number,
+        required: true
+      },
+      hourly_wage: {
+        type: Number,
+        required: true
+      }
+    },
+    task: {
+      type: Object,
+      required: true,
+      id: {
+        type: Number,
+        required: true
+      },
+      total_time: {
+        type: Number,
+        required: true
+      },
+      total_wage: {
+        type: Number,
+        required: true
+      },
+    }
+  },
+
+  data() {
+    return {
+    }
+  },
+
+  computed: {
+    task_take_money(){
+      var task_take_money = Math.floor(this.work.hourly_wage*this.work.work_time/60/60)
+      return task_take_money
+    },
+
+    work_timeH() {
+      var work_timeH = Math.floor(this.work.work_time % (24 * 60 * 60) / (60 * 60));
+      return work_timeH
+    },
+    work_timeM() {
+      var work_timeM = Math.floor(this.work.work_time % (24 * 60 * 60) % (60 * 60) / 60);
+      return work_timeM
+    },
+    work_timeS() {
+      var work_timeS = this.work.work_time % (24 * 60 * 60) % (60 * 60) % 60;
+      return work_timeS
+    },
+
+    total_timeH() {
+      var total_timeH = Math.floor(this.task.total_time % (24 * 60 * 60) / (60 * 60));
+      return total_timeH
+    },
+    total_timeM() {
+      var total_timeM = Math.floor(this.task.total_time % (24 * 60 * 60) % (60 * 60) / 60);
+      return total_timeM
+    },
+    total_timeS() {
+      var total_timeS = this.task.total_time % (24 * 60 * 60) % (60 * 60) % 60;
+      return total_timeS
+    }
+  },
+
+  methods: {
+    handleCloseModal() {
+      this.$emit('close-modal')
+    },
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/app/javascript/pages/task/index.vue
+++ b/app/javascript/pages/task/index.vue
@@ -1,9 +1,5 @@
 <template>
   <div>
-    <h1 class="text-center text-lg">
-      タスク一覧
-    </h1>
-
     <div class="flex flex-wrap">
       <div
         v-for="task in tasks"


### PR DESCRIPTION
## 概要  
既存のタスク詳細画面に時間計測機能を設定しました。  
  
## 確認方法  
1. データ挿入のために`$ bundle exec rails db:seed_fu`を実行してください。
2. タスク詳細画面に移動し、ストップウォッチが表示されていることを確認してください。  
3. 「計測スタート」を押して数秒したのち「計測ストップ」を押したら計測結果モーダルが出るので、今回の計測結果とこれまでの累計が正確に表示されているかを確認してください。  
  
## 影響範囲
- タスクに取り組んだ時間を計測できるようになったため、worksモデルにも干渉するようになりました。  
  
## チェックリスト
#11 を基に以下の事項の修正を行いました。  
- タスク詳細画面にストップウォッチを設定  
- ストップウォッチの計測終了を押すと出現する計測結果モーダルを作成  
- worksコントローラにて時給計算ロジックを作成  
  
その他以下のチェックリストを確認しました。  
- [x] Rubocopをパスした
- [x] Lint のチェックをパスした  
  
## コメント
- worksコントローラで使用している時給計算ロジックを基に、今後追加予定のLINE機能も作成していきます。  