### PR TITLE
Fix: Chart.jsの詳細設定・それに伴うTasksコントローラとWorksコントローラのコード修正・タスク結果モーダルの点数評価カーソルの修正

### DIFF
--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::TasksController < ApplicationController
-  before_action :set_task, only: %i[show update destroy]
+  before_action :set_task, only: %i[show update destroy reset]
 
   def index
     @tasks = Task.where(user_id: current_user.id)
@@ -30,6 +30,18 @@ class Api::V1::TasksController < ApplicationController
 
   def destroy
     @task.destroy!
+    render json: @task
+  end
+
+  def reset
+    @task.total_time = 0
+    @task.total_wage = 0
+    @task.save
+    @works = @task.works
+    # @works.each do |work|
+    #   work.destroy!
+    # end
+    @works.destroy_all!
     render json: @task
   end
 

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -37,11 +37,9 @@ class Api::V1::TasksController < ApplicationController
     @task.total_time = 0
     @task.total_wage = 0
     @task.save
-    @works = @task.works
-    # @works.each do |work|
-    #   work.destroy!
-    # end
-    @works.destroy_all!
+    @task.works.destroy_all
+    # @works = @task.works
+    # @works.destroy_all
     render json: @task
   end
 

--- a/app/javascript/pages/task/components/Chart.vue
+++ b/app/javascript/pages/task/components/Chart.vue
@@ -14,14 +14,12 @@ export default {
   data () {
     return {
       options: {
-        legend: {//凡例設定
-          display: false //表示設定
+        legend: {
+          display: false
         },
         scales: {
           xAxes: [{
             scaleLabel: {
-              // display: true,
-              // labelString: ''
             },
             barPercentage: 0.4
           }],
@@ -29,17 +27,19 @@ export default {
             ticks: {
               beginAtZero: true,
               stepSize: 10000,
+              callback: (value) => `${value}円`,
             }
           }],
-          // y: {
-          //     ticks: {
-          //         // Include a dollar sign in the ticks
-          //         callback: function(value, index, ticks) {
-          //             return '$' + value;
-          //         }
-          //     }
-          // }
-
+        },
+        tooltips: {
+          callbacks: {
+            title: (tooltipItem, data) => {
+              return tooltipItem[0].xLabel;
+            },
+            label: (tooltipItem, data) => {
+              return tooltipItem.yLabel + '円';
+            }
+          }
         }
       }
     }

--- a/app/javascript/pages/task/components/TaskEditModal.vue
+++ b/app/javascript/pages/task/components/TaskEditModal.vue
@@ -210,9 +210,7 @@ export default {
       this.$emit('update-task', this.task)
     },
     handleResetTask() {
-      this.$set(this.task, 'total_time', "0")
-      this.$set(this.task, 'total_wage', "0")
-      this.$emit('update-task', this.task)
+      this.$emit('reset-task', this.task)
     },
     handleDeleteTask() {
       this.$emit('delete-task', this.task)

--- a/app/javascript/pages/task/components/TaskFinishModal.vue
+++ b/app/javascript/pages/task/components/TaskFinishModal.vue
@@ -34,16 +34,6 @@
                 <p class="mb-6">
                   <span class="text-2xl text-red-500">{{ this_task_wage }}</span>円分の働きとなりました!
                 </p>
-                <!-- <p class="mb-3">
-                  これまでの累計時間は
-                  <span class="text-xl">{{ total_timeH }}</span>時間
-                  <span class="text-xl">{{ total_timeM }}</span>分
-                  <span class="text-xl">{{ total_timeS }}</span>秒
-                  となり
-                </p>
-                <p class="mb-10">
-                  累計の金額は<span class="text-2xl text-red-500">{{ task.total_wage }}</span>円となりました!
-                </p> -->
               </div>
               <h3
                 class="leading-6 mb-3"
@@ -58,15 +48,14 @@
                   id="range"
                   v-model="work.evaluation"
                   type="range"
-                  min="0"
+                  min="1"
                   max="10"
                   class="w-full"
                   step="1"
-                  value="5"
                   list="tickmarks"
+                  @change="onScole"
                 >
                 <datalist id="tickmarks">
-                  <option value="0" />
                   <option value="1" />
                   <option value="2" />
                   <option value="3" />
@@ -82,7 +71,15 @@
                   高
                 </p>
               </div>
-              <h1><span class="text-xl">{{ work.evaluation }}</span>点</h1>
+              <h1 v-if="scole===true">
+                <span class="text-xl">{{ work.evaluation }}</span>点
+              </h1> 
+              <h1
+                v-else
+                class="text-red-400 px-4 py-3 rounded relative"
+              >
+                点数を選択してください
+              </h1>
             </div>
           </div>
         </div>
@@ -158,8 +155,13 @@ export default {
 
   data() {
     return {
+      scole: []
     }
   },
+
+  // created(){
+  //   this.work.evaluation = 5;
+  // },
 
   computed: {
     this_task_wage(){
@@ -191,7 +193,7 @@ export default {
     total_timeS() {
       var total_timeS = this.task.total_time % (24 * 60 * 60) % (60 * 60) % 60;
       return total_timeS
-    }
+    },
   },
 
   methods: {
@@ -206,6 +208,10 @@ export default {
     },
     handleDeleteWork() {
       this.$emit('delete-work', this.work, this.task)
+    },
+
+    onScole(){
+      this.scole = true;
     }
   }
 }

--- a/app/javascript/pages/task/components/TaskFinishModal.vue
+++ b/app/javascript/pages/task/components/TaskFinishModal.vue
@@ -97,14 +97,14 @@
           <button
             type="button"
             class="w-full inline-flex justify-center rounded-md border border-transparent shadow px-4 py-2 bg-gradient-to-b hover:bg-gradient-to-t from-blue-400 via-blue-500 to-blue-400 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:ml-3 sm:w-auto sm:text-xs"
-            @click="handleEvaluationWork"
+            @click="handleEvaluationWorkIndex"
           >
             評価してタスクを終了する
           </button>
           <button
             type="button"
             class="w-full inline-flex justify-center rounded-md border border-transparent shadow px-4 py-2 bg-gradient-to-b hover:bg-gradient-to-t from-green-400 via-green-500 to-green-400 text-white hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 sm:ml-3 sm:w-auto sm:text-xs"
-            @click="handleCloseModal"
+            @click="handleEvaluationWorksClose"
           >
             評価してタスクをもう一度計測する
           </button>
@@ -198,8 +198,11 @@ export default {
     handleCloseModal() {
       this.$emit('close-modal')
     },
-    handleEvaluationWork() {
-      this.$emit('evaluation-work', this.work, this.task )
+    handleEvaluationWorksClose() {
+      this.$emit('evaluation-work-close', this.work, this.task)
+    },
+    handleEvaluationWorkIndex() {
+      this.$emit('evaluation-work-index', this.work, this.task )
     },
     handleDeleteWork() {
       this.$emit('delete-work', this.work, this.task)

--- a/app/javascript/pages/task/detail.vue
+++ b/app/javascript/pages/task/detail.vue
@@ -52,6 +52,7 @@
         @close-task-edit-modal="CloseTaskEditModal"
         @update-task="handleUpdateTask"
         @delete-task="handleDeleteTask"
+        @reset-task="handleResetTask"
       />
     </transition>
     <transition name="fade">
@@ -60,8 +61,9 @@
         :work="work"
         :task="task"
         @close-modal="handlecloseTaskFinishModal"
-        @evaluation-work="handleEvaluateThisWork"
-        @delete-work="handleDeleteThisWork"
+        @evaluation-work-index="handleEvaluateWorkIndex"
+        @evaluation-work-close="handleEvaluateWorkClose"
+        @delete-work="handleDeleteWork"
       />
     </transition>
   </div>
@@ -134,7 +136,22 @@ export default {
         .then(res => this.data = res.data)
         this.CloseTaskEditModal();
         this.$store.commit(`message/setContent`,{
-          content: '処理を実行しました!',
+          content: 'タスク名を変更しました!',
+          timeout: 6000
+        })
+      } catch (error) {
+        console.log(error);
+      }
+    },
+
+    async handleResetTask(task) {
+      try {
+        await this.$axios.patch( `${process.env.VUE_BASE_API}/tasks/${task.id}/reset`, task)
+        // .then(res => this.data = res.data)
+        this.CloseTaskEditModal();
+        this.$router.go({path: this.$router.currentRoute.path, force: true})
+        this.$store.commit(`message/setContent`,{
+          content: 'タスクの値をリセットしました!',
           timeout: 6000
         })
       } catch (error) {
@@ -171,9 +188,21 @@ export default {
       this.isVisibleTaskFinishModal = false;
     },
 
+    async handleEvaluateWorkIndex(work, task) {
+      try {
+        await this.$axios.patch( `${process.env.VUE_BASE_API}/tasks/${task.id}/works/${work.id}`, {work, task})
+        .then(res => this.data = res.data)
+        this.$router.push('/tasks')
+        this.$store.commit(`message/setContent`,{
+          content: `評価${work.evaluation}点にて今回のタスクを登録しました!`,
+          timeout: 6000
+        })
+      } catch (error) {
+        console.log(error);
+      }
+    },
 
-
-    async handleEvaluateThisWork(work, task) {
+    async handleEvaluateWorkClose(work, task) {
       try {
         await this.$axios.patch( `${process.env.VUE_BASE_API}/tasks/${task.id}/works/${work.id}`, {work, task})
         .then(res => this.data = res.data)
@@ -187,10 +216,11 @@ export default {
       }
     },
 
-    async handleDeleteThisWork(work, task) {
+    async handleDeleteWork(work, task) {
       try {
         await this.$axios.delete( `${process.env.VUE_BASE_API}/tasks/${task.id}/works/${work.id}`, {work, task})
         this.isVisibleTaskFinishModal = false;
+        this.$router.go({path: this.$router.currentRoute.path, force: true})
         this.$store.commit(`message/setContent`,{
           content: '今回のタスクを無しにしました!',
           timeout: 6000

--- a/app/javascript/pages/task/detail.vue
+++ b/app/javascript/pages/task/detail.vue
@@ -104,6 +104,9 @@ export default {
       var total_timeS = this.task.total_time % (24 * 60 * 60) % (60 * 60) % 60;
       return total_timeS
     },
+    // initialEvaluation(){
+    //   this.work.evaluation = 5;
+    // }
   },
 
   created() {

--- a/app/javascript/pages/task/result.vue
+++ b/app/javascript/pages/task/result.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <!-- 共通画面 -->
     <h1 class="text-center mb-20 text-2xl font-bold">
       <span>{{ task.title }}</span>の推移表
     </h1>
@@ -8,6 +9,7 @@
         id="dating"
         v-model="selectedDating"
         class="appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none"
+        @change="monthlyDataFilter()"
       >
         <option
           disabled
@@ -31,44 +33,106 @@
       </router-link>
     </div>
 
-    <Chart
+    <!-- 日別or月別グラフ表示 -->
+    <div
       v-if="selectedDating===1 || selectedDating===2"
-      :chart-data="dataCollection"
-    />
+      class="w-3/5 mx-auto my-20 p-10 shadow text-center"
+    >
+      <!-- 日別グラフ -->
+      <div v-if="selectedDating===1">
+        <select
+          id="selected_month"
+          v-model="selected_month"
+          class="appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none mb-10"
+          @change="dailyDataFilter()"
+        >
+          <option
+            v-for="month in recent_months" 
+            :key="month.id" 
+            :value="month"
+          >
+            <span>{{ month }}</span>
+          </option>
+        </select> 
+        <div
+          v-if="selected_month.length===0"
+          class="m-20"
+        >
+          <h1>月を選択してください</h1>
+        </div>
+        <div v-else>
+          <h1
+            v-if="work_days.length===0"
+            class="m-20"
+          >
+            No Data
+          </h1>
+          <Chart
+            v-else
+            :chart-data="dataCollection"
+          />
+        </div>
+      </div>
+      <!-- 月別グラフ(現在は2022年のみ) -->
+      <div v-if="selectedDating===2">
+        <h1 class="text-center  mb-10 text-gray-700">
+          2022年
+        </h1>
+        <h1
+          v-if="work_months.length===0"
+          class="m-20"
+        >
+          No Data
+        </h1>
+        <Chart
+          v-else
+          :chart-data="dataCollection"
+        />
+      </div>
+    </div>
   </div>
 </template>
 
 <script>
 import Chart from './components/Chart';
+import moment from 'moment';
 
 export default {
   name: "TaskResult",
   components: {
     Chart,
   },
+
   data() {
     return {
-      task: {},
+      task: [],
 
-      work_days: [],
-      daily_wages: [],
-      daily_evaluated_wages: [],
-
-      work_months: [],
-      monthly_wages: [],
-      monthly_evaluated_wages: [],
-
+      // グラフ選択
       dataCollection: [],
       selectedDating: [], 
       optionDating: [ 
           { id: 1, name: '日別' }, 
           { id: 2, name: '月別' },
-      ], 
+      ],
 
+      // 日別
+      daily_works: [],
+      selected_month: [],
+      recent_months: [],
+      work_days: [],
+      daily_wages: [],
+      daily_evaluated_wages: [],
+
+      // 月別
+      monthly_works: [],
+      work_months: [],
+      monthly_wages: [],
+      monthly_evaluated_wages: [],
     }
   },
 
   computed: {
+    // 累計時間の表示
     total_timeH() {
       var total_timeH = Math.floor(this.task.total_time % (24 * 60 * 60) / (60 * 60));
       return total_timeH
@@ -89,39 +153,56 @@ export default {
   },
 
   beforeUpdate() {
-    this.selected();
+    this.dataSelected();
   },
 
   methods: {
+    // Task取得
     fetchDetailTask() {
       this.$axios.get( `${process.env.VUE_BASE_API}/tasks/${this.$route.params.id}`)
         .then(res => this.task = res.data)
         .catch(err => console.log(err.status));
     },
 
+    // Works取得
     fetchWorks() {
       this.$axios.get( `${process.env.VUE_BASE_API}/tasks/${this.$route.params.id}/works`)
         .then(res => {
-          this.daily_wages = res.data.daily_wages, 
-          this.work_days = res.data.work_days, 
-          this.daily_evaluated_wages = res.data.daily_evaluated_wages 
-          this.monthly_wages = res.data.monthly_wages, 
-          this.work_months = res.data.work_months, 
-          this.monthly_evaluated_wages = res.data.monthly_evaluated_wages})
+          this.daily_works = res.data.daily_works,
+          this.monthly_works = res.data.monthly_works
+          })
         .catch(err => console.log(err.status));
     },
 
-    dailyData() {
+    // 日別と月別を選択した際の動作
+    dataSelected(){
+      if (this.selectedDating === 1) { return this.dailyChart(), this.monthlySelect(); } 
+      else if (this.selectedDating === 2) { return this.montlyChart(), this.monthlyDataFilter(); }
+    },
+
+    // 日別の月選択データ作成
+    monthlySelect(){
+      var arr = [];
+      var i = 0;
+      var start = moment().add(-0, 'years').startOf('year');
+      //とりあえず現状では2022年からなので-0となる
+      var end = moment().startOf('month');
+      var diffmonthes = end.diff(start, 'months');
+      for(; i <= diffmonthes; i++) {
+        arr.push(start.clone().add(i, 'months').startOf('month').format('YYYY-MM'));
+      }
+      this.recent_months = arr.reverse();
+    },
+
+    // 日別データのグラフ
+    dailyChart() {
       this.dataCollection = {
         labels: this.work_days,
         datasets: [
           {
             label: "労働金額",
             data: this.daily_wages,
-            // fillColor: 'rgba(0,0,225,0.5)',//塗りつぶす色
-            // strokeColor: 'rgba(0,0,225,0.5)',//線の色
             backgroundColor : [
-            //   `rgba(0,0,225,${Math.floor(this.daily_evaluated_wages[0]/this.daily_wages[0]*10)/10 } )`,
               `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[0]/10/this.daily_wages[0]*100))/100 } )`,
               `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[1]/10/this.daily_wages[1]*100))/100 } )`,
               `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[2]/10/this.daily_wages[2]*100))/100 } )`,
@@ -129,17 +210,55 @@ export default {
               `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[4]/10/this.daily_wages[4]*100))/100 } )`,
               `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[5]/10/this.daily_wages[5]*100))/100 } )`,
               `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[6]*100))/100 } )`,
-              // `rgba(0,0,225,${Math.floor((this.daily_evaluated_wages[3]/this.daily_wages[3]*10)/10)})`,
-              // `rgba(0,0,225,${Math.floor(this.daily_evaluated_wages[4]/this.daily_wages[4])})`,
-              // `rgba(0,0,225,${Math.floor(this.daily_evaluated_wages[5]/this.daily_wages[5])})`,
-              // `rgba(0,0,225,${Math.floor(this.daily_evaluated_wages[6]/this.daily_wages[6])})`,
-              ]
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[7]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[8]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[9]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[10]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[11]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[12]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[13]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[14]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[15]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[16]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[17]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[18]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[19]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[20]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[21]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[22]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[23]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[24]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[25]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[26]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[27]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[28]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[29]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[30]*100))/100 } )`,
+            ]
           },
         ]
       };
     },
 
-    montlyData() {
+    // Worksを月毎の日別データに選別
+    dailyDataFilter() {
+      this.daily_wages = [];
+      this.work_days = [];
+      this.daily_evaluated_wages = [];
+      var fromDate = moment(this.selected_month).startOf('month').local().format();
+      var endDate = moment(this.selected_month).endOf('month').local().format();
+      var daily_works = this.daily_works.filter(function(item, index){
+        if ( item[0] <= endDate && item[0] >= fromDate ) return true;
+      });
+      for( var i = 0; i < daily_works.length; i++ ){
+        this.work_days.push(`${Number(daily_works[i][0].slice(-2))}日`);
+        this.daily_wages.push(daily_works[i][1]);
+        this.daily_evaluated_wages.push(daily_works[i][2]);
+      }
+    },
+
+    // 月別のデータのグラフ
+    montlyChart() {
       this.dataCollection = {
         labels: this.work_months,
         datasets: [
@@ -153,17 +272,36 @@ export default {
               `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[3]/10/this.monthly_wages[3]*100))/100 } )`,
               `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[4]/10/this.monthly_wages[4]*100))/100 } )`,
               `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[5]/10/this.monthly_wages[5]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[5]/10/this.monthly_wages[6]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[5]/10/this.monthly_wages[7]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[5]/10/this.monthly_wages[8]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[5]/10/this.monthly_wages[9]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[5]/10/this.monthly_wages[10]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[5]/10/this.monthly_wages[11]*100))/100 } )`,
             ]
           },
         ]
       };
     },
 
-    selected(){
-      if (this.selectedDating === 1) { return this.dailyData();} 
-      else if (this.selectedDating === 2) {return this.montlyData();}
-    }
-
+    // worksを年毎の月別データに選別
+    // 月別のデータについては2022年からなので今年のデータのみ取得
+    // 来年以降daily_logと同じ構造にする
+    monthlyDataFilter() {
+      this.monthly_wages = [];
+      this.work_months = [];
+      this.monthly_evaluated_wages = [];
+      var fromMonth = moment().startOf('year').local().format();
+      var endMonth = moment().endOf('year').local().format();
+      var monthly_works = this.monthly_works.filter(function(item, index){
+        if ( item[0] <= endMonth && item[0] >= fromMonth ) return true;
+      });
+      for( var i = 0; i < monthly_works.length; i++ ){
+        this.work_months.push(`${Number(monthly_works[i][0].slice(-2))}月`);
+        this.monthly_wages.push(monthly_works[i][1]);
+        this.monthly_evaluated_wages.push(monthly_works[i][2]);
+      }
+    },
   },
 }
 </script>

--- a/app/javascript/pages/task/result.vue
+++ b/app/javascript/pages/task/result.vue
@@ -76,7 +76,7 @@
       <!-- 月別グラフ(現在は2022年のみ) -->
       <div v-if="selectedDating===2">
         <h1 class="text-center  mb-10 text-gray-700">
-          2022年
+          2022
         </h1>
         <h1
           v-if="work_months.length===0"
@@ -189,7 +189,7 @@ export default {
       var end = moment().startOf('month');
       var diffmonthes = end.diff(start, 'months');
       for(; i <= diffmonthes; i++) {
-        arr.push(start.clone().add(i, 'months').startOf('month').format('YYYY-MM'));
+        arr.push(start.clone().add(i, 'months').startOf('month').format('YYYY/M'));
       }
       this.recent_months = arr.reverse();
     },
@@ -210,30 +210,30 @@ export default {
               `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[4]/10/this.daily_wages[4]*100))/100 } )`,
               `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[5]/10/this.daily_wages[5]*100))/100 } )`,
               `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[6]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[7]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[8]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[9]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[10]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[11]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[12]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[13]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[14]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[15]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[16]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[17]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[18]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[19]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[20]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[21]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[22]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[23]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[24]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[25]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[26]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[27]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[28]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[29]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[6]/10/this.daily_wages[30]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[7]/10/this.daily_wages[7]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[8]/10/this.daily_wages[8]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[9]/10/this.daily_wages[9]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[10]/10/this.daily_wages[10]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[11]/10/this.daily_wages[11]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[12]/10/this.daily_wages[12]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[13]/10/this.daily_wages[13]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[14]/10/this.daily_wages[14]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[15]/10/this.daily_wages[15]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[16]/10/this.daily_wages[16]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[17]/10/this.daily_wages[17]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[18]/10/this.daily_wages[18]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[19]/10/this.daily_wages[19]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[20]/10/this.daily_wages[20]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[21]/10/this.daily_wages[21]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[22]/10/this.daily_wages[22]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[23]/10/this.daily_wages[23]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[24]/10/this.daily_wages[24]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[25]/10/this.daily_wages[25]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[26]/10/this.daily_wages[26]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[27]/10/this.daily_wages[27]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[28]/10/this.daily_wages[28]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[29]/10/this.daily_wages[29]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.daily_evaluated_wages[30]/10/this.daily_wages[30]*100))/100 } )`,
             ]
           },
         ]
@@ -245,8 +245,8 @@ export default {
       this.daily_wages = [];
       this.work_days = [];
       this.daily_evaluated_wages = [];
-      var fromDate = moment(this.selected_month).startOf('month').local().format();
-      var endDate = moment(this.selected_month).endOf('month').local().format();
+      var fromDate = moment(this.selected_month).startOf('month').toISOString();
+      var endDate = moment(this.selected_month).endOf('month').toISOString();
       var daily_works = this.daily_works.filter(function(item, index){
         if ( item[0] <= endDate && item[0] >= fromDate ) return true;
       });
@@ -272,12 +272,12 @@ export default {
               `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[3]/10/this.monthly_wages[3]*100))/100 } )`,
               `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[4]/10/this.monthly_wages[4]*100))/100 } )`,
               `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[5]/10/this.monthly_wages[5]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[5]/10/this.monthly_wages[6]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[5]/10/this.monthly_wages[7]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[5]/10/this.monthly_wages[8]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[5]/10/this.monthly_wages[9]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[5]/10/this.monthly_wages[10]*100))/100 } )`,
-              `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[5]/10/this.monthly_wages[11]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[6]/10/this.monthly_wages[6]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[7]/10/this.monthly_wages[7]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[8]/10/this.monthly_wages[8]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[9]/10/this.monthly_wages[9]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[10]/10/this.monthly_wages[10]*100))/100 } )`,
+              `rgba(0,0,225,${ (Math.floor(this.monthly_evaluated_wages[11]/10/this.monthly_wages[11]*100))/100 } )`,
             ]
           },
         ]
@@ -291,10 +291,10 @@ export default {
       this.monthly_wages = [];
       this.work_months = [];
       this.monthly_evaluated_wages = [];
-      var fromMonth = moment().startOf('year').local().format();
-      var endMonth = moment().endOf('year').local().format();
+      var fromMonth = moment().startOf('year').toISOString();
+      var endMonth = moment().endOf('year').toISOString();
       var monthly_works = this.monthly_works.filter(function(item, index){
-        if ( item[0] <= endMonth && item[0] >= fromMonth ) return true;
+        if ( item[0] <= endMonth && item[0] >= fromMonth) return true;
       });
       for( var i = 0; i < monthly_works.length; i++ ){
         this.work_months.push(`${Number(monthly_works[i][0].slice(-2))}月`);

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -7,4 +7,9 @@ class Task < ApplicationRecord
     self.total_time += work.work_time
     self.total_wage += work.work_wage
   end
+
+  def reset_total_data(work)
+    self.total_time -= work.work_time
+    self.total_wage -= work.work_wage
+  end
 end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -2,8 +2,8 @@ class Work < ApplicationRecord
   before_update :change_evaluation
   belongs_to :task
 
-  scope :work_date, -> { where(created_at: Time.current.beginning_of_month..Time.current.end_of_month).group('date(created_at)') }
-  scope :work_month, -> { where(created_at: Time.current.beginning_of_year..Time.current.end_of_year).group('month(created_at)') }
+  # scope :work_date, -> { where(created_at: Time.current.beginning_of_month..Time.current.end_of_month).group('date(created_at)') }
+  # scope :work_month, -> { where(created_at: Time.current.beginning_of_year..Time.current.end_of_year).group('month(created_at)') }
 
   def time_caliculator
     self.work_time = end_at - start_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,13 +3,10 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :tasks do
-        resources :works, only: [:index, :create, :update, :destroy] do
-          # collection do
-          #   get 'daily_data'
-          #   get 'monthly_data'
-          # end
+        resources :works, only: [:index, :create, :update, :destroy]
+        member do
+          patch 'reset'
         end
-        
       end
       # resources :works
       resources :users do

--- a/db/fixtures/development/03_works.rb
+++ b/db/fixtures/development/03_works.rb
@@ -1,35 +1,35 @@
 Work.seed do |s|
   s.id = 1
-  s.start_at = '2022-01-02 00:00:00'
-  s.end_at = '2022-01-02 02:00:00'
+  s.start_at = '2022-01-01 00:00:00'
+  s.end_at = '2022-01-01 02:00:00'
   s.work_time  = 7200
   s.hourly_wage  = 1000
   s.task_id  = 1
   s.work_wage  = 2000
   s.evaluation = 16000
-  s.created_at = '2022-01-02 02:00:00'
+  s.created_at = '2022-01-01 02:00:00'
 end
 
 Work.seed do |s|
   s.id = 2
-  s.start_at = '2022-01-05 00:00:00'
-  s.end_at = '2022-01-02 05:00:00'
+  s.start_at = '2022-02-05 00:00:00'
+  s.end_at = '2022-02-02 05:00:00'
   s.work_time  = 18000
   s.hourly_wage  = 1000
   s.task_id  = 1
   s.work_wage  = 5000
   s.evaluation = 15000
-  s.created_at = '2022-01-05 05:00:00'
+  s.created_at = '2022-02-05 05:00:00'
 end
 
 Work.seed do |s|
   s.id = 3
-  s.start_at = '2022-01-11 00:00:00'
-  s.end_at = '2022-01-11 03:00:00'
+  s.start_at = '2022-03-11 00:00:00'
+  s.end_at = '2022-03-11 03:00:00'
   s.work_time  = 10800
   s.hourly_wage  = 1000
   s.task_id  = 1
   s.work_wage  = 3000
   s.evaluation = 18000
-  s.created_at = '2022-01-11 03:00:00'
+  s.created_at = '2022-03-11 03:00:00'
 end

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "chart.js": "2.8",
     "css-loader": "^6.7.1",
     "file-loader": "^6.2.0",
+    "moment": "^2.29.1",
     "postcss": "7",
     "postcss-nested": "^5.0.6",
     "style-loader": "^3.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5256,7 +5256,7 @@ modern-normalize@^1.1.0:
   resolved "https://registry.yarnpkg.com/modern-normalize/-/modern-normalize-1.1.0.tgz#da8e80140d9221426bd4f725c6e11283d34f90b7"
   integrity sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==
 
-moment@^2.10.2:
+moment@^2.10.2, moment@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
## 概要
- タスク結果画面において使用するChart.jsの詳細設定(データ受け渡し方法など)を行いました。  
- それに伴いタスクの数値リセット機能が既存のコントローラ設定だとタスク詳細画面とタスク結果グラフにデータのずれが生じてしまうのでWorksコントローラとTasksコントローラを修正しました。  
- タスク結果モーダルの点数評価カーソルを修正しました。  
  
## 確認方法  
1.  seedデータを変更したので`$ bundle exec rails db:reset`と`$ bundle exec rails db:seed_fu`を実行してください。  
2. `$ bundle exec foreman start`を行いローカル環境にてアプリを起動してください。  
3. メールアドレス`sample@example.com`・パスワード`password`にてログインをしてタスク一覧画面に遷移してください。  
4. `A社へ訪問販売`をクリックしてタスク詳細画面に遷移してタスクを実際に計測してください。  
5. 計測を終了したらタスク結果画面で評価点数が初期状態で`点数を選択してください`と表示されていることを確認してください。  
6. 実際に点数をつけて評価をして`評価してタスクをもう一度計測する`を押し、タスク詳細画面にて`タスクの取組状況`を押してください。  
7. タスク取組状況画面にて`日別`を選択したら年月選択バーが表示されるのでそれぞれの月にて登録したデータが表示されることを表示してください。  
8. 同様に`月別`を選択したら登録したデータが表示されていることを確認してください。  
  
## 影響範囲
- タスク結果画面とタスク取組状況画面にて正常にデータが反映されるようになりました。  
  
## チェックリスト
- タスク取組状況画面で使用するChart.jsの設定を変更しました。  
詳しくは...  
日別データにて年月別のデータを選択可能にするためにWorksコントローラ内のworks#indexで処理していたものを一部result.vueにて処理に変更  
日別月別でデータが存在しない時には`No Data`を表示し無駄にグラフを開くことが無いようにしました。  
- 上記の変更をした際にタスク編集における数値リセットをしてもグラフにデータが残ったままの状態になってしまっていた(task.total_timeとtask.total_wageを0にするだけで該当のworkのデータが消えていないため生じていた問題)のでTasksコントローラを修正して該当のworkデータを削除するように設定しました。  
- yarnにてmoment.jsを導入しました。
  
その他以下のチェックリストを確認しました。  
- [x] Rubocopをパスした
- [x] Lint のチェックをパスした  
  
## コメント
- Userのmodelにnameは必要ないと感じたので次回のプルリクエスト時には修正しておきます。  